### PR TITLE
Remove redundant paragonie/random_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
     "require": {
         "php": ">=7.4",
         "2amigos/qrcode-library": "^2.0|^3.0",
-        "paragonie/constant_time_encoding": "^1.4|^2.0|9.99.99",
-        "paragonie/random_compat": "^2.0"
+        "paragonie/constant_time_encoding": "^1.4|^2.0|9.99.99"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",


### PR DESCRIPTION
This package depends on `paragonie/random_compat: ^2.0`, but also `php: >=7.4`. Since `random_bytes` and `random_int` were added in PHP 7.0, the dependency on `paragonie/random_compat` seems redundant?